### PR TITLE
a better example showing use of hyphen in module name

### DIFF
--- a/examples/distribution.pl
+++ b/examples/distribution.pl
@@ -5,7 +5,7 @@ use DDP;
 use MetaCPAN::Client;
 
 my $dist =
-    MetaCPAN::Client->new->distribution('Moose');
+    MetaCPAN::Client->new->distribution('CPAN-Releases-Latest');
 
 my %output = (
     NAME => $dist->name,


### PR DESCRIPTION
had you also considered using

Data::Printer instead of DDP in an example
