### PR TITLE
Don't build a query if a 'body' is already specified

### DIFF
--- a/lib/MetaCPAN/Client/Request.pm
+++ b/lib/MetaCPAN/Client/Request.pm
@@ -81,7 +81,9 @@ sub ssearch {
         index       => $self->version,
         type        => $type,
         size        => 1000,
+        ( $params->{body} ? () :
         body        => $self->_build_body($args),
+        ),
         %{ $params },
     );
 


### PR DESCRIPTION
This enables queries like:

```
my $resultset = $mcpan->module(undef, {
   body => ElasticSearch::SearchBuilder->query({
      'module.name'       => $module,
      maturity            => 'released',
      'module.authorized' => 'true',
      'date'              => { '>=' => $year, '<=' => 2099 },
   }),
});
```

Prior to this tweak, using a still legal query for `$args` like `{ DUMMY => 1 }` would still work, but using `undef` or `''` makes the intent a bit clearer.
