### PR TITLE
Adds failing test to demonstrate that LWP::UserAgent is not currently supported.

### DIFF
--- a/t/useragent.t
+++ b/t/useragent.t
@@ -1,0 +1,20 @@
+#!perl
+
+use strict;
+use warnings;
+
+use LWP::UserAgent;
+use Test::More;
+use Test::Fatal;
+
+use t::lib::Functions;
+
+my $mc = mcpan();
+
+my $mcpan = MetaCPAN::Client->new( ua => LWP::UserAgent->new );
+
+is( exception { $mcpan->author( 'XSAWYERX' ); },
+    undef, 'LWP::UserAgent response parsed',
+);
+
+done_testing();


### PR DESCRIPTION
According to the docs, LWP::UserAgent classes should be supported, but that's currently not the case.  The reason is that the code is now tightly coupled with HTTP::Tiny.

A typical error might look something like this:

```
First argument must be hashref
        at Carp::croak(<eval>:12)
        at MetaCPAN::Client::Request::_decode_result(/Users/olaf/perl5/lib/perl5/MetaCPAN/Client/Request.pm:96)
        at MetaCPAN::Client::Request::fetch(/Users/olaf/perl5/lib/perl5/MetaCPAN/Client/Request.pm:62)
        at MetaCPAN::Client::fetch(<eval>:12)
        at MetaCPAN::Client::_get(/Users/olaf/perl5/lib/perl5/MetaCPAN/Client.pm:167)
        at MetaCPAN::Client::_get_or_search(/Users/olaf/perl5/lib/perl5/MetaCPAN/Client.pm:209)
        at MetaCPAN::Client::author(/Users/olaf/perl5/lib/perl5/MetaCPAN/Client.pm:44)
```

HTTP::Tiny returns a HashRef, but LWP::UserAgent returns a response object.  

I realize that this test introduces a dependency which you are likely trying to avoid, but I wanted to demonstrate the issue properly.  :)
