### PR TITLE
Dependency and Metadata fixes.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,8 @@
 Revision history for MetaCPAN-Client (previously MetaCPAN-API)
+
+1.007001
+            * GH #18: HTTP::Tiny::Mech and WWW::Mechanize::Cached downgraded to being non-essential for tests (kentnl)
+
 1.007000    14.08.14
             * Ensure passing user specified ua values to all parts internally,
               including to Elasticsearch (kentnl) GH #17 RT#95796

--- a/README.pod
+++ b/README.pod
@@ -8,7 +8,7 @@ MetaCPAN::Client - A comprehensive, DWIM-featured client to the MetaCPAN API
 
 =head1 VERSION
 
-version 1.007000
+version 1.007001
 
 =head1 SYNOPSIS
 

--- a/dist.ini
+++ b/dist.ini
@@ -5,7 +5,7 @@ license = Perl_5
 copyright_holder = Sawyer X
 copyright_year   = 2014
 
-version = 1.007000
+version = 1.007001
 
 [@Basic]
 [PodSyntaxTests]
@@ -18,6 +18,11 @@ Search::Elasticsearch = 1.10
 
 [AutoPrereqs]
 skip = ^t::lib::Functions$
+
+[Prereqs::Soften]
+module = HTTP::Tiny::Mech
+module = WWW::Mechanize::Cached
+copy_to = develop.requires
 
 [ModuleBuild]
 [PodWeaver]


### PR DESCRIPTION
When I wrote #17, I wrote the tests with the assumption `HTTP::Tiny::Mech` and `WWW::Mechanize::Cached` would be optional.

However, Autoprereqs has determined them to be mandatory, and this creates a few needless headaches installing dependencies. ( I personally get stuck somewhere because Cache::Cache fails )

So this patch rectifies this using `Dist::Zilla::Plugin::Prereqs::Soften` which moves the deps from `test.requires` to `test.recommends`.

However, at present, `test.recommends` vanish into a black hole, because `dist.ini` only uses `META.yml`, which only supports the `Meta 1.5` spec, and thus, only supports the old crufty options, and none of the new fancy stuff like 'recommends'. (  Amongst other things ).

While I was there, I noticed a great number of contributors presently go unrecognised ( `git shortlog` ), and so I added `[Git::Contributors]` to vivify `x_contributors` so that MetaCPAN can show them.
