### PR TITLE
Include metadata in known fields for ::Release

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,8 @@
 Revision history for MetaCPAN-Client (previously MetaCPAN-API)
+
+1.007001
+            * Include 'metadata' in known_fields for ::Release (kentnl, GH #19)
+
 1.007000    14.08.14
             * Ensure passing user specified ua values to all parts internally,
               including to Elasticsearch (kentnl) GH #17 RT#95796

--- a/lib/MetaCPAN/Client/Release.pm
+++ b/lib/MetaCPAN/Client/Release.pm
@@ -10,7 +10,7 @@ with 'MetaCPAN::Client::Role::Entity';
 my @known_fields = qw<
     resources status date author maturity dependency id authorized
     download_url first archive version name version_numified license
-    distribution stat provides tests abstract
+    distribution stat provides tests abstract metadata
 >;
 
 foreach my $field (@known_fields) {
@@ -74,3 +74,4 @@ __END__
 
 =head2 abstract
 
+=head2 metadata


### PR DESCRIPTION
As per IRC discussion:

``` irc
10:34:30 < kentnl> What do I have to do to get MetaCPAN::Client to return the ->metadata property of a release? It doesn't appear to explicitly select any keys, and I can't see how to explicitly tell it what to ask for.
10:47:40 <@oalders> kentnl: maybe we need to add it to the known_fields? https://metacpan.org/source/MICKEY/MetaCPAN-Client-1.007000/lib/MetaCPAN/Client/Release.pm#L10
10:48:32 <@oalders> or i guess try $release->data->{metadata} ?
10:49:32 < dipsy> [ lib/MetaCPAN/Client/Release.pm - metacpan.org ] 
11:24:11 < kentnl> oalders: thats just it, $release->data->{metadata} is undef :/
11:24:54 < kentnl> the code suggests it pulls "everything", but why metadata doesn't get pulled with "everything" confuses me.
11:29:49 < kentnl> http://paste.scsys.co.uk/428783 # This for example just gives undef in output
11:31:51 < dipsy> [ magnet_web paste from Someone at 217.168.150.38... ] 
11:34:14 < kentnl> pretty printing data itself gives *all* the data, *except* for metadata.
11:34:29 < kentnl> Using the metacpan explorer to extract what fields are seen there, I created this: http://paste.scsys.co.uk/428784 
11:34:40 < kentnl> and in that, .... it only emits "metadata missing in data
11:35:41 < dipsy> [ magnet_web paste from Someone at 217.168.150.38... ] 
11:44:51 < kentnl> hm, adding some sniffing into the network stack does show it is being recieved, so its getting trashed somewhere 
11:46:56 < kentnl> Oh. That's annoying. data is not "all the data", but "the data filtered down to known fields" 
11:47:07 < kentnl> https://metacpan.org/source/MICKEY/MetaCPAN-Client-1.007000/lib/MetaCPAN/Client/Role/Entity.pm#L23 
11:48:13 < dipsy> [ lib/MetaCPAN/Client/Role/Entity.pm - metacpan.org ] 
12:00:45 <@oalders> ah, i wonder why that would be? i just figured it would be everything
12:01:10 <@oalders> which would make things easier for when we add new fields
```

This patch simply adds the missing field.

Discussed test scripts above are:

emits 'undef'

``` perl
#!/usr/bin/env perl

use MetaCPAN::Client;

my $cli = MetaCPAN::Client->new();

my $rel = $cli->release('ETHER/Task-Kensho-0.38');

use Data::Dump qw(pp);

pp( $rel->data->{metadata} ); 
```

emits "metadata missing in data"

``` perl
#!/usr/bin/env perl

use MetaCPAN::Client;

my $cli = MetaCPAN::Client->new();

my $rel = $cli->release('ETHER/Task-Kensho-0.38');

use Data::Dump qw(pp);

my @webkeys = qw( resources status date author maturity dependency id metadata authorized download_url first archive version name version_numified license distribution stat provides tests abstract );

for my $key ( @webkeys ) {
  next if exists $rel->data->{$key};
  print "$key missing in data\n";
}
```

Its probably better to have some kind of more useful long term solution, because a DWIM system isn't very DWIM if it can't access new fields that are created by upstream at _any_ level.
