### PR TITLE
ResultSet.pm: Permit user defined target classes for low-level use.

### DIFF
--- a/lib/MetaCPAN/Client/ResultSet.pm
+++ b/lib/MetaCPAN/Client/ResultSet.pm
@@ -13,7 +13,7 @@ has type => (
             grep { $_ eq $_[0] } qw<author distribution favorite
                                    file module rating release>;
     },
-    required => 1,
+    lazy => 1,
 );
 
 # in case we're returning from a scrolled search
@@ -46,6 +46,12 @@ has total => (
     },
 );
 
+has 'class' => (
+    is      => 'ro',
+    lazy    => 1,
+    builder => '_build_class',
+);
+
 sub BUILDARGS {
     my ( $class, %args ) = @_;
 
@@ -55,7 +61,17 @@ sub BUILDARGS {
     exists $args{scroller} and exists $args{items}
         and croak 'ResultSet must get either scroller or items, not both';
 
+    exists $args{type} or exists $args{class}
+        or croak 'Must pass either type or target class to ResultSet';
+
+    exists $args{type} and exists $args{class}
+        and croak 'Must pass either type or target class to ResultSet, not both';
+
     return \%args;
+}
+sub BUILD {
+    my ( $self ) = @_;
+    $self->class; # vifify and validate
 }
 
 sub next {
@@ -65,14 +81,18 @@ sub next {
 
     defined $result or return;
 
-    my $class = 'MetaCPAN::Client::' . ucfirst $self->type;
-    return $class->new_from_request( $result->{'_source'} || $result->{'fields'} );
+    return $self->class->new_from_request( $result->{'_source'} || $result->{'fields'} );
 }
 
 sub facets {
     my $self = shift;
 
     return $self->has_scroller ? $self->scroller->facets : {};
+}
+
+sub _build_class {
+    my $self = shift;
+    return 'MetaCPAN::Client::' . ucfirst $self->type;
 }
 
 1;

--- a/t/result_custom.t
+++ b/t/result_custom.t
@@ -1,0 +1,44 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+use Test::Fatal qw( exception );
+use MetaCPAN::Client;
+use MetaCPAN::Client::ResultSet;
+
+{
+
+    package Test::Result;
+    use Moo;
+    with 'MetaCPAN::Client::Role::Entity';
+
+    sub new_from_request {
+        my ( $class, $request, $client ) = @_;
+        return $class->new( ( defined $client ? ( client => $client ) : () ),
+            data => $request, );
+    }
+}
+
+my $client = MetaCPAN::Client->new();
+my $scroll = $client->ssearch( 'author', { pauseid => 'KENTNL' } );
+
+my $rs = MetaCPAN::Client::ResultSet->new(
+    class    => 'Test::Result',
+    scroller => $scroll,
+);
+
+isa_ok( $rs, 'MetaCPAN::Client::ResultSet' );
+can_ok( $rs, qw<next facets total type scroller> );
+my $item;
+is( exception { $item = $rs->next; 1 }, undef, "no fail on next" );
+isa_ok( $item, 'Test::Result' );
+note explain $item;
+
+my $ex;
+isnt( $ex = exception { MetaCPAN::Client::ResultSet->new( scroller => $scroll ) },
+      undef, 'Must fail is neither class or type are passed' );
+note $ex;
+
+1;


### PR DESCRIPTION
This makes it easier in cases where you want to return a different type
of object that may have specific extra features added that may not be
useful for MetaCPAN::Client.

This avoids the need for downstream users to do re-blessing in strange
places to get the same result.
