### PR TITLE
oalders/domain

### DIFF
--- a/lib/MetaCPAN/Client.pm
+++ b/lib/MetaCPAN/Client.pm
@@ -31,6 +31,8 @@ sub BUILDARGS {
 
     $args{'request'} ||= MetaCPAN::Client::Request->new(
         ( ua => $args{'ua'} ) x !! $args{'ua'},
+        $args{domain}  ? ( domain => $args{domain} )   : (),
+        $args{version} ? ( version => $args{version} ) : (),
     );
 
     return \%args;

--- a/t/request.t
+++ b/t/request.t
@@ -3,7 +3,8 @@
 use strict;
 use warnings;
 
-use Test::More tests => 7;
+use Test::More tests => 9;
+use MetaCPAN::Client;
 use MetaCPAN::Client::Request;
 
 my $req = MetaCPAN::Client::Request->new( domain => 'mydomain', version => 'z' );
@@ -27,3 +28,6 @@ is_deeply(
     'Correct UA args',
 );
 
+my $client = MetaCPAN::Client->new( domain => 'foo', version => 'bar' );
+is ( $client->request->domain, 'foo', 'domain set in request' );
+is ( $client->request->version, 'bar', 'version set in request' );


### PR DESCRIPTION
The docs say you can set these in the request object directly, but they
also say MetaCPAN::Client->request is for internal use.  It would be
easier if these attributes were settable when creating a new client,
just as the UA is.
