### PR TITLE
Adds eumm_version to dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,6 +10,10 @@ version = 1.028000
 [@Filter]
 -bundle = @Basic
 -remove = GatherDir
+-remove = MakeMaker
+
+[MakeMaker]
+eumm_version = 7.1101
 
 [PodSyntaxTests]
 [PodCoverageTests]


### PR DESCRIPTION
This fixes "[@Filter/MakeMaker] found version range in runtime
prerequisites, which ExtUtils::MakeMaker cannot parse (must specify
eumm_version of at least 7.1101): Search::Elasticsearch >= 2.02, < 5.00"