### PR TITLE
removing Search::Elasticsearch

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -8,6 +8,7 @@ requires "Moo::Role" => "0";
 requires "Net::SSLeay" => "1.49";
 requires "Ref::Util" => "0";
 requires "Safe::Isa" => "0";
+requires "Type::Tiny" => "0";
 requires "URI::Escape";
 requires "perl" => "5.010";
 requires "strict" => "0";

--- a/cpanfile
+++ b/cpanfile
@@ -8,14 +8,12 @@ requires "Moo::Role" => "0";
 requires "Net::SSLeay" => "1.49";
 requires "Ref::Util" => "0";
 requires "Safe::Isa" => "0";
-requires "Search::Elasticsearch" => "== 2.03"; # pinned
 requires "URI::Escape";
 requires "perl" => "5.010";
 requires "strict" => "0";
 requires "warnings" => "0";
 
 on 'test' => sub {
-  requires "Search::Elasticsearch::Scroll" => "0";
   requires "Test::Fatal" => "0";
   requires "Test::More" => "0";
   requires "Test::Requires" => "0";

--- a/lib/MetaCPAN/Client/Pod.pm
+++ b/lib/MetaCPAN/Client/Pod.pm
@@ -6,6 +6,8 @@ package MetaCPAN::Client::Pod;
 use Moo;
 use Carp;
 
+use MetaCPAN::Client::Types qw< Str >;
+
 has request => (
     is       => 'ro',
     handles  => [qw<ua fetch post ssearch>],
@@ -16,9 +18,7 @@ has name => ( is => 'ro', required => 1 );
 
 has url_prefix => (
     is  => 'ro',
-    isa => sub {
-        ref($_[0]) and croak "url_prefix must be a scalar";
-    }
+    isa => Str,
 );
 
 my @known_formats = qw<

--- a/lib/MetaCPAN/Client/Request.pm
+++ b/lib/MetaCPAN/Client/Request.pm
@@ -10,12 +10,11 @@ use HTTP::Tiny;
 use Ref::Util qw< is_arrayref is_hashref >;
 
 use MetaCPAN::Client::Scroll;
+use MetaCPAN::Client::Types qw< HashRef >;
 
 has _clientinfo => (
     is      => 'ro',
-    isa     => sub {
-        is_hashref( $_[0] ) or croak '_clientinfo mush be a hashref';
-    },
+    isa     => HashRef,
     lazy    => 1,
     builder => '_build_clientinfo',
 );

--- a/lib/MetaCPAN/Client/ResultSet.pm
+++ b/lib/MetaCPAN/Client/ResultSet.pm
@@ -5,7 +5,8 @@ package MetaCPAN::Client::ResultSet;
 
 use Moo;
 use Carp;
-use Ref::Util qw< is_arrayref >;
+
+use MetaCPAN::Client::Types qw< ArrayRef >;
 
 has type => (
     is       => 'ro',
@@ -31,10 +32,7 @@ has scroller => (
 # in case we're returning from a fetch
 has items => (
     is  => 'ro',
-    isa => sub {
-        is_arrayref($_[0])
-            or croak 'items must be an array ref';
-    },
+    isa => ArrayRef,
 );
 
 has total => (

--- a/lib/MetaCPAN/Client/ResultSet.pm
+++ b/lib/MetaCPAN/Client/ResultSet.pm
@@ -22,8 +22,8 @@ has scroller => (
     is        => 'ro',
     isa       => sub {
         use Safe::Isa;
-        $_[0]->$_isa('Search::Elasticsearch::Scroll')
-            or croak 'scroller must be an Search::Elasticsearch::Scroll object';
+        $_[0]->$_isa('MetaCPAN::Client::Scroll')
+            or croak 'scroller must be an MetaCPAN::Client::Scroll object';
     },
     predicate => 'has_scroller',
 );
@@ -91,7 +91,7 @@ provides easy access to the scroller and aggregations.
 
 =head2 scroller
 
-An L<Search::Elasticsearch::Scroll> object.
+An L<MetaCPAN::Client::Scroll> object.
 
 =head2 items
 

--- a/lib/MetaCPAN/Client/Scroll.pm
+++ b/lib/MetaCPAN/Client/Scroll.pm
@@ -1,0 +1,214 @@
+use strict;
+use warnings;
+package MetaCPAN::Client::Scroll;
+# ABSTRACT: A MetaCPAN::Client scroller
+
+use Moo;
+use Carp;
+use Ref::Util qw< is_arrayref is_hashref is_ref >;
+use JSON::MaybeXS qw< decode_json encode_json >;
+
+has ua => (
+    is       => 'ro',
+    required => 1,
+);
+
+has size => (
+    is  => 'ro',
+    isa => sub {
+        is_ref($_[0]) and croak 'size must be a scalar';
+    },
+);
+
+has time => (
+    is  => 'ro',
+    isa => sub {
+        is_ref($_[0]) and croak 'time must be a scalar';
+    },
+);
+
+has base_url => (
+    is  => 'ro',
+    isa => sub {
+        is_ref($_[0]) and croak 'base_url must be a scalar';
+    },
+    required => 1,
+);
+
+has type => (
+    is  => 'ro',
+    isa => sub {
+        is_ref($_[0]) and croak 'type must be a scalar';
+    },
+    required => 1,
+);
+
+has body => (
+    is  => 'ro',
+    isa => sub {
+        is_hashref($_[0]) or croak 'body must be a hashref';
+    },
+    required => 1,
+);
+
+has _id => (
+    is  => 'ro',
+    isa => sub {
+        is_ref($_[0]) and croak 'id must be a scalar';
+    },
+    required => 1,
+);
+
+has total => (
+    is  => 'ro',
+    isa => sub {
+        is_ref($_[0]) or $_[0] =~ /[^0-9]/
+            and croak 'total must be a number';
+    },
+    required => 1,
+);
+
+has _read => (
+    is  => 'ro',
+    isa => sub {
+        is_ref($_[0]) or $_[0] =~ /[^0-9]/
+            and croak 'total must be a number';
+    },
+    default => sub { 0 },
+    writer  => '_set_read',
+);
+
+has _buffer => (
+    is  => 'ro',
+    isa => sub {
+        is_arrayref($_[0]) or croak 'buffer must be an array ref';
+    },
+    default => sub { [] },
+);
+
+has aggregations => (
+    is  => 'ro',
+    isa => sub {
+        is_hashref($_[0]) or croak 'aggregations must be an hash ref';
+    },
+    default => sub { +{} },
+);
+
+sub BUILDARGS {
+    my ( $class, %args ) = @_;
+    $args{time} //= '5m';
+    $args{size} //= '100';
+
+    my ( $ua, $base_url, $type, $body, $time, $size ) =
+        @args{qw< ua base_url type body time size >};
+
+    # fetch scroller from server
+
+    my $res = $ua->post(
+        sprintf( '%s/%s/_search?scroll=%s&size=%s', $base_url, $type, $time, $size ),
+        { content => encode_json $body }
+    );
+
+    croak "failed to create a scrolled search"
+        unless $res->{status} == 200;
+
+    my $content = decode_json $res->{content};
+
+    # read response content --> object params
+
+    $args{_id}   = $content->{_scroll_id};
+    $args{total} = $content->{hits}{total};
+
+    push @{ $args{_buffer} } => @{ $content->{hits}{hits} };
+
+    $args{aggregations} = $content->{aggregations}
+        if $content->{aggregations} and is_hashref( $content->{aggregations} );
+
+    return \%args;
+}
+
+sub next {
+    my $self = shift;
+    return if $self->_read >= $self->total;
+
+    $self->_fetch_next unless @{ $self->_buffer };
+
+    $self->_set_read( $self->_read + 1 );
+    return shift @{ $self->_buffer };
+}
+
+sub _fetch_next {
+    my $self = shift;
+
+    my $res = $self->ua->post(
+        sprintf( '%s/_search/scroll?scroll=%s&size=%s', $self->base_url, $self->time, $self->size ),
+        { content => $self->_id }
+    );
+
+    croak "failed to fetch next scolled batch"
+        unless $res->{status} == 200;
+
+    my $content = decode_json $res->{content};
+
+    push @{ $self->_buffer } => @{ $content->{hits}{hits} };
+}
+
+sub DEMOLISH {
+    my $self = shift;
+
+    my $res = $self->ua->delete(
+        sprintf( '%s/_search/scroll?scroll=%s', $self->base_url, $self->time ),
+        { content => $self->_id }
+    );
+
+    warn "failed to delete scroller"
+        unless $res->{status} == 200;
+}
+
+1;
+__END__
+
+=head1 METHODS
+
+=head2 next
+
+get next matched document.
+
+=head2 BUILDARGS
+
+=head2 DEMOLISH
+
+=head1 ATTRIBUTES
+
+=head2 aggregations
+
+The returned aggregations structure from agg
+requests.
+
+=head2 base_url
+
+The base URL for sending server requests.
+
+=head2 body
+
+The request body.
+
+=head2 size
+
+The numebr of docs to pull from each shard per request.
+
+=head2 time
+
+The lifetime of the scroller on the server.
+
+=head2 total
+
+The total number of matches.
+
+=head2 type
+
+The ElasticSearch type to query.
+
+=head2 ua
+
+The user agent object for running requests.

--- a/lib/MetaCPAN/Client/Scroll.pm
+++ b/lib/MetaCPAN/Client/Scroll.pm
@@ -5,8 +5,10 @@ package MetaCPAN::Client::Scroll;
 
 use Moo;
 use Carp;
-use Ref::Util qw< is_arrayref is_hashref is_ref >;
+use Ref::Util qw< is_hashref >;
 use JSON::MaybeXS qw< decode_json encode_json >;
+
+use MetaCPAN::Client::Types qw< Str Int Time ArrayRef HashRef >;
 
 has ua => (
     is       => 'ro',
@@ -15,82 +17,60 @@ has ua => (
 
 has size => (
     is  => 'ro',
-    isa => sub {
-        is_ref($_[0]) and croak 'size must be a scalar';
-    },
+    isa => Str,
 );
 
 has time => (
     is  => 'ro',
-    isa => sub {
-        is_ref($_[0]) and croak 'time must be a scalar';
-    },
+    isa => Time,
 );
 
 has base_url => (
-    is  => 'ro',
-    isa => sub {
-        is_ref($_[0]) and croak 'base_url must be a scalar';
-    },
+    is       => 'ro',
+    isa      => Str,
     required => 1,
 );
 
 has type => (
-    is  => 'ro',
-    isa => sub {
-        is_ref($_[0]) and croak 'type must be a scalar';
-    },
+    is       => 'ro',
+    isa      => Str,
     required => 1,
 );
 
 has body => (
-    is  => 'ro',
-    isa => sub {
-        is_hashref($_[0]) or croak 'body must be a hashref';
-    },
+    is       => 'ro',
+    isa      => HashRef,
     required => 1,
 );
 
 has _id => (
-    is  => 'ro',
-    isa => sub {
-        is_ref($_[0]) and croak 'id must be a scalar';
-    },
+    is       => 'ro',
+    isa      => Str,
     required => 1,
 );
 
 has total => (
-    is  => 'ro',
-    isa => sub {
-        is_ref($_[0]) or $_[0] =~ /[^0-9]/
-            and croak 'total must be a number';
-    },
+    is       => 'ro',
+    isa      => Int,
     required => 1,
 );
 
 has _read => (
-    is  => 'ro',
-    isa => sub {
-        is_ref($_[0]) or $_[0] =~ /[^0-9]/
-            and croak 'total must be a number';
-    },
+    is      => 'ro',
+    isa     => Int,
     default => sub { 0 },
     writer  => '_set_read',
 );
 
 has _buffer => (
-    is  => 'ro',
-    isa => sub {
-        is_arrayref($_[0]) or croak 'buffer must be an array ref';
-    },
+    is      => 'ro',
+    isa     => ArrayRef,
     default => sub { [] },
 );
 
 has aggregations => (
-    is  => 'ro',
-    isa => sub {
-        is_hashref($_[0]) or croak 'aggregations must be an hash ref';
-    },
+    is      => 'ro',
+    isa     => HashRef,
     default => sub { +{} },
 );
 

--- a/lib/MetaCPAN/Client/Types.pm
+++ b/lib/MetaCPAN/Client/Types.pm
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+package MetaCPAN::Client::Types;
+# ABSTRACT: type checking helper class
+
+use Type::Tiny      ();
+use Types::Standard ();
+use Ref::Util qw< is_ref >;
+
+use parent 'Exporter';
+our @EXPORT_OK = qw< Str Int Time ArrayRef HashRef >;
+
+sub Str      { Types::Standard::Str      }
+sub Int      { Types::Standard::Int      }
+sub ArrayRef { Types::Standard::ArrayRef }
+sub HashRef  { Types::Standard::HashRef  }
+
+sub Time {
+    return Type::Tiny->new(
+        name       => "Time",
+        constraint => sub { !is_ref($_) and /^[1-9][0-9]*(?:s|m|h)$/ },
+        message    => sub { "$_ is not in time format (e.g. '5m')" },
+    );
+}
+
+1;
+__END__
+
+=head1 METHODS
+
+=head2 ArrayRef
+
+=head2 HashRef
+
+=head2 Int
+
+=head2 Str
+
+=head2 Time

--- a/t/api/favorite.t
+++ b/t/api/favorite.t
@@ -15,6 +15,5 @@ foreach my $option ( { author => 'XSAWYERX' }, { dist => 'MetaCPAN-Client' } ) {
     isa_ok( $rs, 'MetaCPAN::Client::ResultSet' );
     can_ok( $rs, qw<type scroller> );
     is( $rs->type, 'favorite', 'Correct resultset type' );
-    isa_ok( $rs->scroller, 'Search::Elasticsearch::Scroll' );
+    isa_ok( $rs->scroller, 'MetaCPAN::Client::Scroll' );
 }
-

--- a/t/resultset.t
+++ b/t/resultset.t
@@ -9,7 +9,7 @@ use MetaCPAN::Client::ResultSet;
 
 {
     package MetaCPAN::Client::Test::ScrollerZ;
-    use base 'Search::Elasticsearch::Scroll'; # < 5.10 FTW (except, no)
+    use base 'MetaCPAN::Client::Scroll'; # < 5.10 FTW (except, no)
     sub total {0}
 }
 
@@ -26,7 +26,7 @@ like(
 
 my $rs = MetaCPAN::Client::ResultSet->new(
     type     => 'author',
-    scroller => bless {}, 'Search::Elasticsearch::Scroll',
+    scroller => bless {}, 'MetaCPAN::Client::Scroll',
 );
 
 isa_ok( $rs, 'MetaCPAN::Client::ResultSet' );

--- a/t/scroll.t
+++ b/t/scroll.t
@@ -1,0 +1,38 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 6;
+use Ref::Util qw< is_hashref >;
+use HTTP::Tiny;
+use MetaCPAN::Client::Scroll;
+use MetaCPAN::Client::Release;
+
+my $scroller = MetaCPAN::Client::Scroll->new(
+   ua       => HTTP::Tiny->new,
+   base_url => 'https://fastapi.metacpan.org/v1/',
+   type     => 'release',
+   body     => { query => { term => { distribution => 'MetaCPAN-Client' } } },
+   size     => 5,
+);
+isa_ok( $scroller, 'MetaCPAN::Client::Scroll' );
+
+can_ok(
+    $scroller,
+    qw< aggregations base_url body _buffer
+        BUILDARGS DEMOLISH _fetch_next _id
+        next _read size time total type ua >
+);
+
+my $next = $scroller->next;
+ok( is_hashref($next), 'next doc returns a hashref' );
+
+my $rel = MetaCPAN::Client::Release->new_from_request( $next->{'_source'} );
+isa_ok( $rel, 'MetaCPAN::Client::Release' );
+is( $rel->distribution, 'MetaCPAN-Client', 'release object can be created from next doc' );
+
+while ( my $n = $scroller->next ) { 1 }
+is( $scroller->total, $scroller->_read, 'can read all matching docs' );
+
+1;


### PR DESCRIPTION
#55 and other complaints regarding this issue convinced me we got to get rid of the S::Es usage (we only use it for scrolled searches) - it's a pain and its current (and probably future) breaking changes will only make it even more of a nightmare.

As I see it, while we don't upgrade to it, we have some users (+testers) having issues with it. if we do, we open a can of worms and will have to support all issues people will have with it (we will have to force them to upgrade, as the same code doesn't work on both 2.03 and 5.x).
 
I figured it's just an API to an API to I'm using the destination one directly here.