### PR TITLE
support passing time/size params for the scroller

### DIFF
--- a/Changes
+++ b/Changes
@@ -146,7 +146,7 @@ Revision history for MetaCPAN-Client (previously MetaCPAN-API)
 
 1.010000    23.01.15
             * support wildcard-only value in complex search (mickeyn)
-            * support raw ElasticSearch filters in 'all' queries (mickeyn)
+            * support raw Elasticsearch filters in 'all' queries (mickeyn)
 
 1.009000    11.01.15
             * GH #25 (RT #99499): added support for 'fields' filtering (mickeyn, oalders)
@@ -226,7 +226,7 @@ Revision history for MetaCPAN-Client (previously MetaCPAN-API)
                 * Simple queries return entity objects
                 * Complex queries return resultset objects (with iterator)
                 * Support for scrolled searches
-                * Inline support for ElasticSearch facets
+                * Inline support for Elasticsearch facets
                 * Documentation, tests - all cleaned, rewritten
 
 0.43        05.04.12

--- a/lib/MetaCPAN/Client.pm
+++ b/lib/MetaCPAN/Client.pm
@@ -605,6 +605,30 @@ we can't to begin with (like non-leaf fields that hold a structure)
 
     my $module = $mcpan->all('releases', { _source => "stat" });
 
+=head2 scroller_time
+
+Note: please use with caution.
+
+This parameter will set the max. lifetime of the ElasticSearch scroller
+on the server (default = '5m').
+Normally you do not need to set this value (as tweaking this value can
+affect resources on the server);
+in case you do - you probably need to check the efficiency of your
+code/queries (feel free to reach out to us for assistance).
+
+    my $module = $mcpan->all('releases', { scroller_time => "3m" });
+
+=head2 scroller_size
+
+Note: please use with caution.
+
+This parameter will set the buffer size to be pulled from ElasticSearch
+when scrolling (default = 1000).
+This will affect query performance and memory usage, but you will still
+get an iterator back to fetch one object at a time.
+
+    my $module = $mcpan->all('releases', { scroller_size => 500 });
+
 =head1 SEARCH SPEC
 
 The hash-based search spec is common to many searches. It is quite

--- a/lib/MetaCPAN/Client.pm
+++ b/lib/MetaCPAN/Client.pm
@@ -498,7 +498,7 @@ Returns a L<MetaCPAN::Client::Mirror> object.
 
 =head2 reverse_dependencies
 
-    my $deps = $mcpan->reverse_dependencies('ElasticSearch');
+    my $deps = $mcpan->reverse_dependencies('Search::Elasticsearch');
 
 all L<MetaCPAN::Client::Release> objects of releases that are dependent
 on a given module, returned as L<MetaCPAN::Client::ResultSet>.
@@ -564,7 +564,7 @@ See SEARCH PARAMS.
 
 =head3 es_filter
 
-Pass a raw ElasticSearch filter structure to reduce the number
+Pass a raw Elasticsearch filter structure to reduce the number
 of elements returned by the query.
 
     my $some_releases = $mcpan->all('releases', { es_filter => {...} })
@@ -591,13 +591,13 @@ can be passed as a csv list or an array ref.
 
 =head2 _source
 
-Note: this param and its description are a bit too ElasticSearch specific.
+Note: this param and its description are a bit too Elasticsearch specific.
 just like 'es_filter' - use only if you know what you're dealing with.
 
-Some fields are not indexed in ElasticSearch but stored as part of
+Some fields are not indexed in Elasticsearch but stored as part of
 the entire document.
 
-These fields can still be read, but without the internal ElasticSearch
+These fields can still be read, but without the internal Elasticsearch
 optimizations and the server will interally read the whole document.
 
 Why do we even need those? because we don't index everything and some things
@@ -621,7 +621,7 @@ reach out to us for assistance).
 
 Note: please use with caution.
 
-This parameter will set the buffer size to be pulled from ElasticSearch
+This parameter will set the buffer size to be pulled from Elasticsearch
 when scrolling (default = 1000).
 This will affect query performance and memory usage, but you will still
 get an iterator back to fetch one object at a time.

--- a/lib/MetaCPAN/Client.pm
+++ b/lib/MetaCPAN/Client.pm
@@ -609,14 +609,13 @@ we can't to begin with (like non-leaf fields that hold a structure)
 
 Note: please use with caution.
 
-This parameter will set the max. lifetime of the ElasticSearch scroller
-on the server (default = '5m').
-Normally you do not need to set this value (as tweaking this value can
-affect resources on the server);
-in case you do - you probably need to check the efficiency of your
-code/queries (feel free to reach out to us for assistance).
+This parameter will set the maximum lifetime of the Elasticsearch scroller on
+the server (default = '5m').  Normally you do not need to set this value (as
+tweaking this value can affect resources on the server).  In case you do, you
+probably need to check the efficiency of your code/queries.  (Feel free to
+reach out to us for assistance).
 
-    my $module = $mcpan->all('releases', { scroller_time => "3m" });
+    my $module = $mcpan->all('releases', { scroller_time => '3m' });
 
 =head2 scroller_size
 

--- a/lib/MetaCPAN/Client/Request.pm
+++ b/lib/MetaCPAN/Client/Request.pm
@@ -377,5 +377,5 @@ Fetches a path from MetaCPAN (post or get), and returns the decoded result.
 
 =head2 ssearch
 
-Calls an ElasticSearch query and returns an L<MetaCPAN::Client::Scroll>
+Calls an Elasticsearch query and returns an L<MetaCPAN::Client::Scroll>
 scroller object.

--- a/lib/MetaCPAN/Client/Request.pm
+++ b/lib/MetaCPAN/Client/Request.pm
@@ -132,9 +132,13 @@ sub ssearch {
     my $args   = shift;
     my $params = shift;
 
+    my $time = delete $params->{'scroller_time'} || '5m';
+    my $size = delete $params->{'scroller_size'} || '1000';
+
     my $scroller = MetaCPAN::Client::Scroll->new(
         ua       => $self->ua,
-        size     => 1000,
+        size     => $size,
+        time     => $time,
         base_url => $self->base_url,
         type     => $type,
         body     => $self->_build_body($args, $params),

--- a/lib/MetaCPAN/Client/Request.pm
+++ b/lib/MetaCPAN/Client/Request.pm
@@ -133,7 +133,7 @@ sub ssearch {
     my $params = shift;
 
     my $time = delete $params->{'scroller_time'} || '5m';
-    my $size = delete $params->{'scroller_size'} || '1000';
+    my $size = delete $params->{'scroller_size'} || 1000;
 
     my $scroller = MetaCPAN::Client::Scroll->new(
         ua       => $self->ua,

--- a/lib/MetaCPAN/Client/Scroll.pm
+++ b/lib/MetaCPAN/Client/Scroll.pm
@@ -205,7 +205,7 @@ The total number of matches.
 
 =head2 type
 
-The ElasticSearch type to query.
+The Elasticsearch type to query.
 
 =head2 ua
 


### PR DESCRIPTION
Adding support for using setting of scroller time/size values.

I want to make sure the wording in the doc explains that it's not recommended to use / you have to understand what these params do.