### PR TITLE
Fix GH #72: Buildling without '.' in @INC (5.26.0)

### DIFF
--- a/t/api/_get.t
+++ b/t/api/_get.t
@@ -5,6 +5,7 @@ use warnings;
 use Test::More tests => 13;
 use Test::Fatal;
 
+use lib '.';
 use t::lib::Functions;
 
 {

--- a/t/api/_get_or_search.t
+++ b/t/api/_get_or_search.t
@@ -5,6 +5,7 @@ use warnings;
 use Test::More tests => 10;
 use Test::Fatal;
 
+use lib '.';
 use t::lib::Functions;
 
 {

--- a/t/api/_search.t
+++ b/t/api/_search.t
@@ -5,6 +5,7 @@ use warnings;
 use Test::More tests => 19;
 use Test::Fatal;
 
+use lib '.';
 use t::lib::Functions;
 
 {

--- a/t/api/author.t
+++ b/t/api/author.t
@@ -6,6 +6,7 @@ use Test::More;
 use Test::Fatal;
 use Ref::Util qw< is_arrayref >;
 
+use lib '.';
 use t::lib::Functions;
 
 my $mc = mcpan();

--- a/t/api/distribution.t
+++ b/t/api/distribution.t
@@ -6,6 +6,7 @@ use Test::More tests => 9;
 use Test::Fatal;
 use Ref::Util qw< is_hashref >;
 
+use lib '.';
 use t::lib::Functions;
 
 my $mc = mcpan();

--- a/t/api/download_url.t
+++ b/t/api/download_url.t
@@ -5,6 +5,7 @@ use warnings;
 use Test::More tests => 7;
 use Test::Fatal;
 
+use lib '.';
 use t::lib::Functions;
 
 my $mc = mcpan();

--- a/t/api/favorite.t
+++ b/t/api/favorite.t
@@ -5,6 +5,7 @@ use warnings;
 use Test::More tests => 2 + 4 * 2;
 use Test::Fatal;
 
+use lib '.';
 use t::lib::Functions;
 
 my $mc = mcpan();

--- a/t/api/file.t
+++ b/t/api/file.t
@@ -5,6 +5,7 @@ use warnings;
 use Test::More tests => 11;
 use Test::Fatal;
 
+use lib '.';
 use t::lib::Functions;
 
 my $mc = mcpan();

--- a/t/api/module.t
+++ b/t/api/module.t
@@ -5,6 +5,7 @@ use warnings;
 use Test::More tests => 10;
 use Test::Fatal;
 
+use lib '.';
 use t::lib::Functions;
 
 my $mc = mcpan();

--- a/t/api/pod.t
+++ b/t/api/pod.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use Test::More tests => 5;
 
+use lib '.';
 use t::lib::Functions;
 
 my $mc = mcpan();

--- a/t/api/rating.t
+++ b/t/api/rating.t
@@ -5,6 +5,7 @@ use warnings;
 use Test::More tests => 7;
 use Test::Fatal;
 
+use lib '.';
 use t::lib::Functions;
 
 my $mc = mcpan();

--- a/t/api/release.t
+++ b/t/api/release.t
@@ -5,6 +5,7 @@ use warnings;
 use Test::More tests => 5;
 use Test::Fatal;
 
+use lib '.';
 use t::lib::Functions;
 
 my $mc = mcpan();


### PR DESCRIPTION
As kentfredric explains in GH #72, the missing dot in @INC (which
goes in 5.26.0) can break any test that uses t::lib::Functions,
assuming that it is available.

While this will work in a new Test::Harness, it wouldn't work for
people running it manually not under Test::Harness. (And we would
have to require that new version as a minimum dependency.)

Instead, this assures it is available when loading
t::lib::Functions.