### PR TITLE
Added 'metacpan_url' method for fetching MetaCPAN links of module, re…

### DIFF
--- a/examples/metacpan_url.pl
+++ b/examples/metacpan_url.pl
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use MetaCPAN::Client;
+
+my $mcpan = MetaCPAN::Client->new();
+
+my $auth = $mcpan->author('HAARG');
+my $mod  = $mcpan->module('Moo');
+my $file = $mcpan->file('HAARG/Moo-2.003001/lib/Moo.pm');
+my $dist = $mcpan->distribution('Moo');
+my $rel  = $mcpan->release({
+    all => [
+        { distribution => 'Moo' },
+        { version => '2.002005' },
+    ]
+});
+
+printf "AUTHOR       : %s\n", $auth->metacpan_url;
+printf "RELEASE      : %s\n", $rel->next->metacpan_url;
+printf "MODULE       : %s\n", $mod->metacpan_url;
+printf "FILE         : %s\n", $file->metacpan_url;
+printf "DISTRIBUTION : %s\n", $dist->metacpan_url;
+
+1;

--- a/lib/MetaCPAN/Client/Author.pm
+++ b/lib/MetaCPAN/Client/Author.pm
@@ -66,6 +66,8 @@ sub releases {
 
 sub dir { $_[0]->links->{cpan_directory} }
 
+sub metacpan_url { "https://metacpan.org/author/" . $_[0]->pauseid }
+
 1;
 
 __END__
@@ -255,3 +257,7 @@ by author.
 This method returns a L<MetaCPAN::Client::ResultSet> of
 L<MetaCPAN::Client::Release> objects. It includes all of the author's releases
 with the C<latest> status.
+
+=head2 metacpan_url
+
+Returns a link to the author's page on MetaCPAN.

--- a/lib/MetaCPAN/Client/Distribution.pm
+++ b/lib/MetaCPAN/Client/Distribution.pm
@@ -42,6 +42,8 @@ sub _known_fields { return \%known_fields }
 sub rt     { $_[0]->bugs->{rt}     || {} }
 sub github { $_[0]->bugs->{github} || {} }
 
+sub metacpan_url { "https://metacpan.org/release/" . $_[0]->name }
+
 1;
 
 __END__
@@ -103,3 +105,7 @@ hashref.
 
 Returns the hashref of data for the github bug tracker. This defaults to an
 empty hashref.
+
+=head2 metacpan_url
+
+Returns a link to the distribution page on MetaCPAN.

--- a/lib/MetaCPAN/Client/File.pm
+++ b/lib/MetaCPAN/Client/File.pm
@@ -90,6 +90,12 @@ sub source {
         );
 }
 
+sub metacpan_url {
+    my $self = shift;
+    sprintf("https://metacpan.org/source/%s/%s/%s",
+            $self->author, $self->release, $self->path );
+}
+
 1;
 
 __END__
@@ -279,3 +285,7 @@ Supported types: B<plain>, B<html>, B<x-pod>, B<x-markdown>.
     my $source = $module->source();
 
 Returns the source code for the file.
+
+=head2 metacpan_url
+
+Returns a link to the file source page on MetaCPAN.

--- a/lib/MetaCPAN/Client/Module.pm
+++ b/lib/MetaCPAN/Client/Module.pm
@@ -6,6 +6,12 @@ package MetaCPAN::Client::Module;
 use Moo;
 extends 'MetaCPAN::Client::File';
 
+sub metacpan_url {
+    my $self = shift;
+    sprintf("https://metacpan.org/pod/release/%s/%s/%s",
+            $self->author, $self->release, $self->path );
+}
+
 1;
 
 __END__
@@ -23,3 +29,9 @@ This is currently the exact same as L<MetaCPAN::Client::File>.
 =head1 ATTRIBUTES
 
 Whatever L<MetaCPAN::Client::File> has.
+
+=head1 METHODS
+
+=head2 metacpan_url
+
+Returns a link to the module page on MetaCPAN.

--- a/lib/MetaCPAN/Client/Release.pm
+++ b/lib/MetaCPAN/Client/Release.pm
@@ -55,6 +55,11 @@ foreach my $field (@known_fields) {
 
 sub _known_fields { return \%known_fields }
 
+sub metacpan_url {
+    my $self = shift;
+    sprintf( "https://metacpan.org/release/%s/%s", $self->author, $self->name )
+}
+
 1;
 
 __END__
@@ -199,3 +204,9 @@ The file's size in bytes.
 Returns a hashref of information about CPAN testers results for this
 release. The keys are C<pass>, C<fail>, C<unknown>, and C<na>. The values are
 the count of that particular result on CPAN Testers for this release.
+
+=head1 METHODS
+
+=head2 metacpan_url
+
+Returns a link to the release page on MetaCPAN.


### PR DESCRIPTION
#69 

added 'metacpan_url' method to Module, Release and Author types.

Is anything missing? (I don't think Distribution has a representation page on the frontend)