### PR TITLE
Remove duplicate (and subtly different) supported types check in ->all

### DIFF
--- a/lib/MetaCPAN/Client.pm
+++ b/lib/MetaCPAN/Client.pm
@@ -174,9 +174,10 @@ sub all {
     my $type   = shift;
     my $params = shift;
 
-    grep { $type eq $_ } qw/ authors distributions modules releases
-                             favorites ratings mirrors files package /
-        or croak "all: unsupported type";
+    # This endpoint used to support only pluralized types (mostly) and convert
+    # to singular types before redispatching.  Now it accepts both plural and
+    # unplural forms directly and relies on the underlying methods it
+    # dispatches to to check types (using the global supported types array).
     $type =~ s/s$//;
 
     $params and !is_hashref($params)


### PR DESCRIPTION
Note that the local array was just a copy of @supported_types but with
"s" appended to all values except package (and the elements reordered).

This method redispatches to methods which will do the type check anyway.