### PR TITLE
Rewrite the scroller to stop skipping a page

### DIFF
--- a/lib/MetaCPAN/Client/Types.pm
+++ b/lib/MetaCPAN/Client/Types.pm
@@ -8,12 +8,13 @@ use Types::Standard ();
 use Ref::Util qw< is_ref >;
 
 use parent 'Exporter';
-our @EXPORT_OK = qw< Str Int Time ArrayRef HashRef >;
+our @EXPORT_OK = qw< Str Int Time ArrayRef HashRef Bool >;
 
 sub Str      { Types::Standard::Str      }
 sub Int      { Types::Standard::Int      }
 sub ArrayRef { Types::Standard::ArrayRef }
 sub HashRef  { Types::Standard::HashRef  }
+sub Bool     { Types::Standard::Bool     }
 
 sub Time {
     return Type::Tiny->new(

--- a/t/scroll.t
+++ b/t/scroll.t
@@ -22,7 +22,7 @@ can_ok(
     $scroller,
     qw< aggregations base_url body _buffer
         BUILDARGS DEMOLISH _fetch_next _id
-        next _read size time total type ua >
+        next size time total type ua >
 );
 
 my $next = $scroller->next;
@@ -32,7 +32,8 @@ my $rel = MetaCPAN::Client::Release->new_from_request( $next->{'_source'} );
 isa_ok( $rel, 'MetaCPAN::Client::Release' );
 is( $rel->distribution, 'MetaCPAN-Client', 'release object can be created from next doc' );
 
-while ( my $n = $scroller->next ) { 1 }
-is( $scroller->_read, $scroller->total, 'can read all matching docs' );
+my $got = 1;  # we call ->next once above
+while ( my $n = $scroller->next ) { $got++ }
+is( $got, $scroller->total, 'can read all matching docs' );
 
 1;


### PR DESCRIPTION
On a large scroll over all of the "package" documents, the scroller was
implicated in consistently dropping a page of results.  The bookkeeping
by the scroller was a bit dodgy, so rather than figure out where the
off-by-one bug was, I just rewrote it.  Normally more rigor in
understanding the root cause is nice, but it's been a long day already
full of other hilarious bugs.