### PR TITLE
small spelling glitch

### DIFF
--- a/lib/MetaCPAN/Client.pm
+++ b/lib/MetaCPAN/Client.pm
@@ -659,7 +659,7 @@ Some fields are not indexed in Elasticsearch but stored as part of
 the entire document.
 
 These fields can still be read, but without the internal Elasticsearch
-optimizations and the server will interally read the whole document.
+optimizations and the server will internally read the whole document.
 
 Why do we even need those? because we don't index everything and some things
 we can't to begin with (like non-leaf fields that hold a structure)


### PR DESCRIPTION

In Debian we are currently applying the following patch to
MetaCPAN-Client.
We thought you might be interested in it too.

    Description: small spelling glitch
     interally -> internally

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libmetacpan-client-perl.git/plain/debian/patches/spelling.patch

Thanks for considering,
  Damyan Ivanov,
  Debian Perl Group
