### PR TITLE
Permit user defined target classes for low-level use

### DIFF
--- a/lib/MetaCPAN/Client/ResultSet.pm
+++ b/lib/MetaCPAN/Client/ResultSet.pm
@@ -15,7 +15,7 @@ has type => (
             grep { $_ eq $_[0] } qw<author distribution favorite
                                    file module rating release mirror package>;
     },
-    required => 1,
+    lazy => 1,
 );
 
 # in case we're returning from a scrolled search
@@ -45,6 +45,12 @@ has total => (
     },
 );
 
+has 'class' => (
+    is      => 'ro',
+    lazy    => 1,
+    builder => '_build_class',
+);
+
 sub BUILDARGS {
     my ( $class, %args ) = @_;
 
@@ -54,7 +60,17 @@ sub BUILDARGS {
     exists $args{scroller} and exists $args{items}
         and croak 'ResultSet must get either scroller or items, not both';
 
+    exists $args{type} or exists $args{class}
+        or croak 'Must pass either type or target class to ResultSet';
+
+    exists $args{type} and exists $args{class}
+        and croak 'Must pass either type or target class to ResultSet, not both';
+
     return \%args;
+}
+sub BUILD {
+    my ( $self ) = @_;
+    $self->class; # vifify and validate
 }
 
 sub next {
@@ -64,8 +80,7 @@ sub next {
 
     defined $result or return;
 
-    my $class = 'MetaCPAN::Client::' . ucfirst $self->type;
-    return $class->new_from_request( $result->{'_source'} || $result->{'fields'} || $result );
+    return $self->class->new_from_request( $result->{'_source'} || $result->{'fields'} || $result );
 }
 
 sub aggregations {
@@ -74,6 +89,10 @@ sub aggregations {
     return $self->has_scroller ? $self->scroller->aggregations : {};
 }
 
+sub _build_class {
+    my $self = shift;
+    return 'MetaCPAN::Client::' . ucfirst $self->type;
+}
 
 1;
 

--- a/t/result_custom.t
+++ b/t/result_custom.t
@@ -30,7 +30,7 @@ my $rs = MetaCPAN::Client::ResultSet->new(
 );
 
 isa_ok( $rs, 'MetaCPAN::Client::ResultSet' );
-can_ok( $rs, qw<next facets total type scroller> );
+can_ok( $rs, qw<next aggregations total type scroller> );
 my $item;
 is( exception { $item = $rs->next; 1 }, undef, "no fail on next" );
 isa_ok( $item, 'Test::Result' );

--- a/t/result_custom.t
+++ b/t/result_custom.t
@@ -19,6 +19,8 @@ use MetaCPAN::Client::ResultSet;
         return $class->new( ( defined $client ? ( client => $client ) : () ),
             data => $request, );
     }
+
+    sub _known_fields { +{} }
 }
 
 my $client = MetaCPAN::Client->new();

--- a/t/result_custom.t
+++ b/t/result_custom.t
@@ -1,0 +1,44 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+use Test::Fatal qw( exception );
+use MetaCPAN::Client;
+use MetaCPAN::Client::ResultSet;
+
+{
+
+    package Test::Result;
+    use Moo;
+    with 'MetaCPAN::Client::Role::Entity';
+
+    sub new_from_request {
+        my ( $class, $request, $client ) = @_;
+        return $class->new( ( defined $client ? ( client => $client ) : () ),
+            data => $request, );
+    }
+}
+
+my $client = MetaCPAN::Client->new();
+my $scroll = $client->ssearch( 'author', { pauseid => 'KENTNL' } );
+
+my $rs = MetaCPAN::Client::ResultSet->new(
+    class    => 'Test::Result',
+    scroller => $scroll,
+);
+
+isa_ok( $rs, 'MetaCPAN::Client::ResultSet' );
+can_ok( $rs, qw<next facets total type scroller> );
+my $item;
+is( exception { $item = $rs->next; 1 }, undef, "no fail on next" );
+isa_ok( $item, 'Test::Result' );
+note explain $item;
+
+my $ex;
+isnt( $ex = exception { MetaCPAN::Client::ResultSet->new( scroller => $scroll ) },
+      undef, 'Must fail is neither class or type are passed' );
+note $ex;
+
+1;

--- a/t/result_custom.t
+++ b/t/result_custom.t
@@ -36,11 +36,7 @@ can_ok( $rs, qw<next aggregations total type scroller> );
 my $item;
 is( exception { $item = $rs->next; 1 }, undef, "no fail on next" );
 isa_ok( $item, 'Test::Result' );
-note explain $item;
 
 my $ex;
 isnt( $ex = exception { MetaCPAN::Client::ResultSet->new( scroller => $scroll ) },
       undef, 'Must fail is neither class or type are passed' );
-note $ex;
-
-1;


### PR DESCRIPTION
I had #20 open in a tab for a while. I rebased it, fixed the conflict, fixed the test, and here it is.

I suggest also updating the documentation so it is clear that you can now also override the class entirely and provide an example - like the test case, before merging.