### PR TITLE
Test reverse dependencies

### DIFF
--- a/t/api/reverse-dependencies.t
+++ b/t/api/reverse-dependencies.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Fatal;
+use Ref::Util qw< is_hashref >;
+
+use lib '.';
+use t::lib::Functions;
+
+my $mc = mcpan();
+can_ok( $mc, qw< reverse_dependencies rev_deps > );
+
+my $module = 'MetaCPAN::Client';
+
+my $rs = $mc->reverse_dependencies($module);
+isa_ok( $rs, 'MetaCPAN::Client::ResultSet' );
+
+my @revdeps;
+
+while ( my $release = $rs->next ) {
+    is(
+        ref $release,
+        'MetaCPAN::Client::Release',
+        'ResultSet->next with ' . $release->distribution . ' is ok',
+    ),
+
+    push @revdeps, $release->distribution;
+}
+
+ok( @revdeps > 2, 'revdep count for MetaCPAN::Client seems ok' );
+
+foreach my $dep (@revdeps) {
+    $dep =~ s/-/::/g;
+
+    my $ok = eval {
+        $mc->module($dep)->name;
+        1;
+    };
+
+    is( $ok, 1, "$dep is a valid reverse dependency" );
+}
+
+# Counting here would be fragile since it depends on dependency changes
+done_testing();


### PR DESCRIPTION
This is a recreation of PR #90.

I have fixed up the styling and cleaned it up a bit. I couldn't find the
original repo that had this commit so I just copied it.

The original code was written by Steve Bertrand (@stevieb9).

I also removed the counting of the tests themselves because it seems to
be a fragile practice. We cannot control all of our reverse dependency
and any additional one uploaded to CPAN would break any existing
version until the counter is adjusted.

I would also note this test takes a few seconds to run. Any automatic CI
tsting would have to take that into account and monitored if it exceeds
the timeout for the entire testing suite.