### PR TITLE
Support checksum_{sha256,md5} fields in Release and DownloadURL

### DIFF
--- a/lib/MetaCPAN/Client/DownloadURL.pm
+++ b/lib/MetaCPAN/Client/DownloadURL.pm
@@ -8,7 +8,7 @@ use Moo;
 with 'MetaCPAN::Client::Role::Entity';
 
 my %known_fields = (
-    scalar   => [qw< date download_url status version >],
+    scalar   => [qw< checksum_md5 checksum_sha256 date download_url status version >],
     arrayref => [],
     hashref  => [],
 );
@@ -42,6 +42,14 @@ __END__
 A MetaCPAN download_url entity object.
 
 =head1 ATTRIBUTES
+
+=head2 checksum_sha256
+
+The sha256 hexdigest for the file.
+
+=head2 checksum_md5
+
+The md5 hexdigest for the file.
 
 =head2 date
 

--- a/lib/MetaCPAN/Client/Release.pm
+++ b/lib/MetaCPAN/Client/Release.pm
@@ -16,6 +16,8 @@ my %known_fields = (
         archive
         author
         authorized
+        checksum_md5
+        checksum_sha256
         date
         deprecated
         distribution
@@ -133,6 +135,14 @@ A boolean indicating whether or not this was an authorized release.
 =head2 download_url
 
 A URL for this release's distribution archive file.
+
+=head2 checksum_sha256
+
+The sha256 hexdigest for this release's distribution archive file.
+
+=head2 checksum_md5
+
+The md5 hexdigest for this release's distribution archive file.
 
 =head2 first
 

--- a/t/api/download_url.t
+++ b/t/api/download_url.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 15;
+use Test::More tests => 17;
 use Test::Fatal;
 
 use lib '.';
@@ -29,6 +29,12 @@ can_ok( $mc, 'rating' );
     is $rs->download_url(),
         q[https://cpan.metacpan.org/authors/id/F/FL/FLORA/Moose-1.01.tar.gz],
         'download_url for Moose-1.01';
+    is $rs->checksum_sha256(),
+        q[f4424f4d709907dea8bc9de2a37b9d3fef4f87775a8c102f432c48a1fdf8067b],
+        'sha256 for Moose-1.0.1.tar.gz';
+    is $rs->checksum_md5(),
+        q[f13f9c203d099f5dc6117f59bda96340],
+        'md5 for Moose-1.0.1.tar.gz';
 }
 
 {

--- a/t/api/release.t
+++ b/t/api/release.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 5;
+use Test::More tests => 7;
 use Test::Fatal;
 
 use lib '.';
@@ -15,4 +15,5 @@ my $release = $mc->release('MetaCPAN-API');
 isa_ok( $release, 'MetaCPAN::Client::Release' );
 can_ok( $release, qw<distribution> );
 is( $release->distribution, 'MetaCPAN-API', 'Correct distribution' );
-
+like($release->checksum_sha256, qr/^[a-f0-9]{64}$/, 'Has a sha256 hexdigest');
+like($release->checksum_md5, qr/^[a-f0-9]{32}$/, 'Has a md5 hexdigest');


### PR DESCRIPTION
This PR adds the `checksum_sha256` and `checksum_md5` attributes that are returned by fastapi.metacpan.org/v1/ for `Release` and `DownloadUrl`.