### PR TITLE
Replace "propagated" with populated in docs

### DIFF
--- a/lib/MetaCPAN/Client.pm
+++ b/lib/MetaCPAN/Client.pm
@@ -505,7 +505,7 @@ reference. Since it is common to many other searches, it is explained below
 under C<SEARCH SPEC>.
 
 Returns a L<MetaCPAN::Client::Author> object on a simple search (PAUSE ID), or
-a L<MetaCPAN::Client::ResultSet> object propagated with
+a L<MetaCPAN::Client::ResultSet> object populated with
 L<MetaCPAN::Client::Author> objects on a complex (L<search spec based|/"SEARCH SPEC">) search.
 
 =head2 cover
@@ -524,7 +524,7 @@ defined by a hash reference. Since it is common to many other searches, it is
 explained below under C<SEARCH SPEC>.
 
 Returns a L<MetaCPAN::Client::Distribution> object on a simple search
-(distribution name), or a L<MetaCPAN::Client::ResultSet> object propagated with
+(distribution name), or a L<MetaCPAN::Client::ResultSet> object populated with
 L<MetaCPAN::Client::Distribution> objects on a complex (L<search spec based|/"SEARCH SPEC">)
 search.
 
@@ -556,7 +556,7 @@ a hash reference. Since it is common to many other searches, it is explained
 below under C<SEARCH SPEC>.
 
 Returns a L<MetaCPAN::Client::Release> object on a simple search (release name),
-or a L<MetaCPAN::Client::ResultSet> object propagated with
+or a L<MetaCPAN::Client::ResultSet> object populated with
 L<MetaCPAN::Client::Release> objects on a complex (L<search spec based|/"SEARCH SPEC">) search.
 
 =head2 mirror
@@ -575,7 +575,7 @@ reference. Since it is common to many other searches, it is explained below
 under C<SEARCH SPEC>.
 
 Returns a L<MetaCPAN::Client::Module> object on a simple search (module name), or
-a L<MetaCPAN::Client::ResultSet> object propagated with
+a L<MetaCPAN::Client::ResultSet> object populated with
 L<MetaCPAN::Client::Module> objects on a complex (L<search spec based|/"SEARCH SPEC">) search.
 
 =head2 package


### PR DESCRIPTION
The word "propagate" doesn't really make sense in this context.