### PR TITLE
Set `verify_SSL=>1` for default HTTP::Tiny user agent

### DIFF
--- a/lib/MetaCPAN/Client/Role/HasUA.pm
+++ b/lib/MetaCPAN/Client/Role/HasUA.pm
@@ -23,7 +23,8 @@ has ua => (
 has ua_args => (
     is      => 'ro',
     default => sub {
-        [ agent => 'MetaCPAN::Client/'.($MetaCPAN::Client::VERSION||'xx') ]
+        [ agent => 'MetaCPAN::Client/'.($MetaCPAN::Client::VERSION||'xx'),
+          verify_SSL => 1 ]
     },
 );
 

--- a/t/request.t
+++ b/t/request.t
@@ -23,7 +23,8 @@ isa_ok( $req->ua, 'HTTP::Tiny' );
 my $ver = $MetaCPAN::Client::VERSION || 'xx';
 is_deeply(
     $req->ua_args,
-    [ agent => "MetaCPAN::Client/$ver" ],
+    [ agent => "MetaCPAN::Client/$ver",
+      verify_SSL => 1 ],
     'Correct UA args',
 );
 


### PR DESCRIPTION
HTTP::Tiny doesn't verify TLS/SSL certificates by default. This PR sets that flag for the default user agent to make sure we connect to legitimate API endpoints.

Example: MetaCPAN::Client will perform a request (that returns 404 Not Found) against `https://wrong.host.badssl.com`:

```
$ perl -Ilib -MMetaCPAN::Client -E 'my $m = MetaCPAN::Client->new(domain=>"https://wrong.host.badssl.com");say $m->release("MetaCPAN-Client")->name;'
Failed to fetch 'https://wrong.host.badssl.com/release/MetaCPAN-Client': Not Found at lib/MetaCPAN/Client.pm line 288.
```
