### PR TITLE
t/api/reverse-dependencies.t - fix check against revdeps

### DIFF
--- a/t/api/reverse-dependencies.t
+++ b/t/api/reverse-dependencies.t
@@ -30,13 +30,10 @@ while ( my $release = $rs->next ) {
 ok( @revdeps > 2, 'revdep count for MetaCPAN::Client seems ok' );
 
 foreach my $dep (@revdeps) {
-    $dep =~ s/-/::/g;
-
     my $ok = eval {
-        $mc->module($dep)->name;
+        $mc->distribution($dep)->name;
         1;
     };
-
     is( $ok, 1, "$dep is a valid reverse dependency" );
 }
 


### PR DESCRIPTION
The array @revdeps contains a list of distributions, so let's not assume the dist names match modules.
Instead, we can check them as a valid distribution name.