### PR TITLE
Fix some scroller issues

### DIFF
--- a/lib/MetaCPAN/Client.pm
+++ b/lib/MetaCPAN/Client.pm
@@ -38,6 +38,7 @@ sub BUILDARGS {
 
     $args{'request'} ||= MetaCPAN::Client::Request->new(
         ( ua     => $args{ua}     )x!! $args{ua},
+        ( ua_args => $args{ua_args} )x!! $args{ua_args},
         ( domain => $args{domain} )x!! $args{domain},
         ( debug  => $args{debug}  )x!! $args{debug},
     );

--- a/lib/MetaCPAN/Client/Scroll.pm
+++ b/lib/MetaCPAN/Client/Scroll.pm
@@ -143,11 +143,21 @@ sub _fetch_next {
 }
 
 sub DEMOLISH {
-    my $self = shift;
+    my ( $self, $gd ) = @_;
+    return
+        if $gd;
+    my $ua = $self->ua
+        or return;
+    my $base_url = $self->base_url
+        or return;
+    my $id = $self->_id
+        or return;
+    my $time = $self->time
+        or return;
 
-    $self->ua->delete(
-        sprintf( '%s/_search/scroll?scroll=%s', $self->base_url, $self->time ),
-        { content => $self->_id }
+    $ua->delete(
+        sprintf( '%s/_search/scroll?scroll=%s', $base_url, $time ),
+        { content => $id }
     );
 }
 


### PR DESCRIPTION
Fixes two issues with the scroller.

First is that if it failed to get scroll id, it would fail partly through object construction but would still try to delete the scroll.

Second is that even if all of the results were included in the first request, it would still try to fetch from the scroller a second time before stopping.

Also fix the User-Agent string being passed to the constructor, and thus the UA used by the tests.