### PR TITLE
remove rating fetching

### DIFF
--- a/lib/MetaCPAN/Client.pm
+++ b/lib/MetaCPAN/Client.pm
@@ -132,7 +132,7 @@ sub rating {
     is_hashref($args)
         or croak 'rating takes a hash ref as parameter';
 
-    return $self->_search( 'rating', $args, $params );
+    return _empty_result_set('rating');
 }
 
 sub release {

--- a/t/api/rating.t
+++ b/t/api/rating.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 7;
+use Test::More tests => 4;
 use Test::Fatal;
 
 use lib '.';
@@ -14,13 +14,3 @@ can_ok( $mc, 'rating' );
 my $rs = $mc->rating( { distribution => 'Moose' } );
 isa_ok( $rs, 'MetaCPAN::Client::ResultSet' );
 can_ok( $rs, 'next' );
-
-my $rating = $rs->next;
-isa_ok( $rating, 'MetaCPAN::Client::Rating' );
-can_ok( $rating, 'distribution' );
-is( $rating->distribution, 'Moose', 'Correct distribution' );
-
-__END__
-can_ok( $rs, 'name' );
-is( $rating->name, 'MetaCPAN-Client', 'Correct distribution' );
-


### PR DESCRIPTION
When asked to retrieve ratings, just give an empty result. CPANRatings has been gone for a long time, and the data is all stale and will be going away.

For now, leave the result class and rating method in place for backward compatibility.