### PR TITLE
Remove backpan_directory option as backend is removing

### DIFF
--- a/lib/MetaCPAN/Client/Author.pm
+++ b/lib/MetaCPAN/Client/Author.pm
@@ -200,10 +200,6 @@ currently known keys are:
 
 The author's CPAN directory.
 
-=item * backpan_directory
-
-The author's BackCPAN directory.
-
 =item * cpantesters_reports
 
 The author's CPAN Testers Reports page.


### PR DESCRIPTION
See: https://github.com/metacpan/metacpan-puppet/issues/253