### PR TITLE
Fix validation compatabilty for ES 8

### DIFF
--- a/lib/MetaCPAN/Client/Scroll.pm
+++ b/lib/MetaCPAN/Client/Scroll.pm
@@ -96,10 +96,15 @@ sub BUILDARGS {
 
     # read response content --> object params
 
-    $args{_id}     = $content->{_scroll_id};
-    $args{total}   = $content->{hits}{total};
-    $args{_buffer} = $content->{hits}{hits};
-    $args{_remaining} = $content->{hits}{total};
+    my $total = is_hashref($content->{hits}{total})
+        ? $content->{hits}{total}{value}
+        : $content->{hits}{total};
+
+    $args{_remaining} = $total;
+    $args{total}      = $total;
+
+    $args{_id}        = $content->{_scroll_id};
+    $args{_buffer}    = $content->{hits}{hits};
 
     $args{aggregations} = $content->{aggregations}
         if $content->{aggregations} and is_hashref( $content->{aggregations} );


### PR DESCRIPTION
We're still seeing issues with a test following the ES 8 data change.
This will check whether `hits.total` is a number (Int) or a hash where the value is in `hits.total.value`.