### PR TITLE
fix es_filter to merge into query

### DIFF
--- a/lib/MetaCPAN/Client/Request.pm
+++ b/lib/MetaCPAN/Client/Request.pm
@@ -156,9 +156,10 @@ sub _build_body {
         ? { match_all => {} }
         : _build_query_rec($args);
 
+    $query = $self->_apply_filters($query, $params);
+
     return +{
         query => $query,
-        $self->_read_filters($params),
         $self->_read_fields($params),
         $self->_read_aggregations($params),
         $self->_read_sort($params)
@@ -206,14 +207,15 @@ sub _read_aggregations {
     return ( aggregations => $aggregations );
 }
 
-sub _read_filters {
+sub _apply_filters {
     my $self   = shift;
+    my $query  = shift;
     my $params = shift;
 
     my $filter = delete $params->{es_filter};
-    is_ref($filter) or return ();
+    is_ref($filter) or return $query;
 
-    return ( filter => $filter );
+    return { bool => { must => [ $filter, $query ] } };
 }
 
 sub _read_sort {

--- a/t/api/author.t
+++ b/t/api/author.t
@@ -101,4 +101,21 @@ while ( my $john = $johns->next ) {
     );
 }
 
+{
+    my $daves = $mc->author( {
+        either => [
+            { name => 'Dave *'  },
+            { name => 'David *' },
+        ],
+    }, {
+        es_filter => {
+            wildcard => { 'name' => 'Dave S*' },
+        }
+    } );
+
+    isa_ok( $daves, 'MetaCPAN::Client::ResultSet' );
+    can_ok( $daves, 'total' );
+    ok( $daves->total < $most_daves, 'Definitely less Daves' );
+}
+
 done_testing;


### PR DESCRIPTION
Newer Elasticsearch versions don't support 'filter' as a top level query option, instead requiring it to be part of the 'query'.