### PR TITLE
Add a supported user_agent constructor option

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for MetaCPAN-Client (previously MetaCPAN-API)
 
+{{$NEXT}}
+            * Add a supported user_agent option for setting the HTTP::Tiny agent string
+
 2.040000    09.03.26
             * Use a boolean in reverse_deps term (Olaf Alders, GH#136)
             * Allow JSON->true and JSON->false (Olaf Alders, GH#137)

--- a/README.pod
+++ b/README.pod
@@ -57,6 +57,15 @@ instead of the default, which is L<HTTP::Tiny>.
 Then it can be used to fetch the user agent object used by
 L<MetaCPAN::Client::Request>.
 
+=head2 user_agent
+
+Sets the user agent string used for the built-in L<HTTP::Tiny> client.
+
+    my $mcpan = MetaCPAN::Client->new( user_agent => 'MyApp/1.0' );
+
+If you need full control over the HTTP stack, continue to pass a custom C<ua>
+object or explicit C<ua_args>.
+
 =head2 domain
 
 If given, will be used to alter the API domain.

--- a/lib/MetaCPAN/Client.pm
+++ b/lib/MetaCPAN/Client.pm
@@ -39,10 +39,11 @@ sub BUILDARGS {
     my ( $class, %args ) = @_;
 
     $args{'request'} ||= MetaCPAN::Client::Request->new(
-        ( ua     => $args{ua}     )x!! $args{ua},
-        ( ua_args => $args{ua_args} )x!! $args{ua_args},
-        ( domain => $args{domain} )x!! $args{domain},
-        ( debug  => $args{debug}  )x!! $args{debug},
+        ( ua         => $args{ua}         )x!! $args{ua},
+        ( ua_args    => $args{ua_args}    )x!! $args{ua_args},
+        ( user_agent => $args{user_agent} )x!! $args{user_agent},
+        ( domain     => $args{domain}     )x!! $args{domain},
+        ( debug      => $args{debug}      )x!! $args{debug},
     );
 
     return \%args;
@@ -505,6 +506,15 @@ instead of the default, which is L<HTTP::Tiny>.
 
 Then it can be used to fetch the user agent object used by
 L<MetaCPAN::Client::Request>.
+
+=head2 user_agent
+
+Sets the user agent string used for the built-in L<HTTP::Tiny> client.
+
+    my $mcpan = MetaCPAN::Client->new( user_agent => 'MyApp/1.0' );
+
+If you need full control over the HTTP stack, continue to pass a custom C<ua>
+object or explicit C<ua_args>.
 
 =head2 domain
 

--- a/lib/MetaCPAN/Client/Role/HasUA.pm
+++ b/lib/MetaCPAN/Client/Role/HasUA.pm
@@ -20,13 +20,20 @@ has ua => (
     builder  => '_build_ua',
 );
 
+has user_agent => (
+    is      => 'ro',
+    lazy    => 1,
+    builder => '_build_user_agent',
+);
+
 has ua_args => (
     is      => 'ro',
-    default => sub {
-        [ agent => 'MetaCPAN::Client/'.($MetaCPAN::Client::VERSION||'xx'),
-          verify_SSL => 1 ]
-    },
+    default => sub { [] },
 );
+
+sub _build_user_agent {
+    return 'MetaCPAN::Client/' . ($MetaCPAN::Client::VERSION || 'xx');
+}
 
 sub _build_ua {
     my $self = shift;
@@ -43,7 +50,11 @@ sub _build_ua {
         return $self->_user_ua;
     }
 
-    return HTTP::Tiny->new( @{ $self->ua_args } );
+    return HTTP::Tiny->new(
+        agent      => $self->user_agent,
+        verify_SSL => 1,
+        @{ $self->ua_args },
+    );
 }
 
 1;
@@ -78,6 +89,16 @@ Must return a result hashref which has key C<success> and key C<content>.
 
 Default: L<HTTP::Tiny>,
 
+=head2 user_agent
+
+    my $mcpan = MetaCPAN::Client->new(
+        user_agent => 'MyApp/1.0',
+    );
+
+Sets the user agent string used by the built-in L<HTTP::Tiny> client.
+
+Default: B<MetaCPAN::Client/$version>.
+
 =head2 ua_args
 
     my $mcpan = MetaCPAN::Client->new(
@@ -86,4 +107,5 @@ Default: L<HTTP::Tiny>,
 
 Arguments sent to the user agent.
 
-Default: user agent string: B<MetaCPAN::Client/$version>.
+Default: none. These arguments are applied on top of the default
+C<HTTP::Tiny-E<gt>new> construction and may override C<user_agent>.

--- a/t/request.t
+++ b/t/request.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 7;
+use Test::More tests => 12;
 use MetaCPAN::Client;
 use MetaCPAN::Client::Request;
 
@@ -21,12 +21,25 @@ is( $req->base_url, 'https://mydomain', 'Correct base_url' );
 isa_ok( $req->ua, 'HTTP::Tiny' );
 
 my $ver = $MetaCPAN::Client::VERSION || 'xx';
-is_deeply(
-    $req->ua_args,
-    [ agent => "MetaCPAN::Client/$ver",
-      verify_SSL => 1 ],
-    'Correct UA args',
-);
+is_deeply( $req->ua_args, [], 'ua_args defaults empty' );
+is( $req->ua->{agent}, "MetaCPAN::Client/$ver", 'default user_agent comes from builder' );
 
 my $client = MetaCPAN::Client->new( domain => 'foo' );
 is ( $client->request->domain, 'foo', 'domain set in request' );
+
+my $tagged_req = MetaCPAN::Client::Request->new(
+    domain     => 'https://mydomain',
+    user_agent => ' partner-app/1.2 ',
+);
+like( $tagged_req->ua->{agent}, qr/^\spartner-app\/1\.2\s+HTTP-Tiny\/[\d._]+$/, 'user_agent sets the HTTP::Tiny agent string' );
+
+my $tagged_client = MetaCPAN::Client->new( domain => 'foo', user_agent => 'partner-app/1.2' );
+is( $tagged_client->request->ua->{agent}, 'partner-app/1.2', 'client forwards user_agent to request construction' );
+
+my $explicit_req = MetaCPAN::Client::Request->new(
+    domain     => 'https://mydomain',
+    user_agent => 'partner-app/1.2',
+    ua_args    => [ agent => 'Explicit/9.9', verify_SSL => 1 ],
+);
+is_deeply( $explicit_req->ua_args, [ agent => 'Explicit/9.9', verify_SSL => 1 ], 'explicit ua_args are preserved' );
+is( $explicit_req->ua->{agent}, 'Explicit/9.9', 'explicit ua_args still take precedence over user_agent' );


### PR DESCRIPTION
This adds a documented `user_agent` constructor option for callers who want to tag traffic without replacing the entire HTTP client.

Behavior:
- preserves existing behavior when unset
- appends the custom token to the default `MetaCPAN::Client/<version>` agent string
- leaves custom `ua` objects unchanged
- leaves explicit `ua_args` behavior unchanged

Example:

```perl
my $mcpan = MetaCPAN::Client->new(
    user_agent => 'MyApp/1.0',
);
```

Tests/docs included:
- request-level coverage for default/customized/precedence behavior
- POD/README updates
- Changes entry

Issue: #128
