### PR TITLE
Add missing types to 'all' POD section

### DIFF
--- a/lib/MetaCPAN/Client.pm
+++ b/lib/MetaCPAN/Client.pm
@@ -689,7 +689,8 @@ Returns a L<MetaCPAN::Client::DownloadURL> object
 
 =head2 all
 
-Retrieve all matches for authors/modules/distributions/favorites or releases.
+Retrieve all matches for
+authors/modules/distributions/favorites/files/permissions/packages/covers/cves or releases.
 
     my $all_releases = $mcpan->all('releases')
 


### PR DESCRIPTION
I haven't added `ratings` and `mirrors` because they don't return anything, so not sure if that's right.

Closes #139